### PR TITLE
bump to version 1.10.4

### DIFF
--- a/alby-hub.nix
+++ b/alby-hub.nix
@@ -24,7 +24,7 @@ buildGoModule {
       # add frontend drv output to src
       cp -r ${albyHubUI}/dist $out/frontend/dist
     '';
-  vendorHash = "sha256-zztq5V+Ax7BQQL6NGKOR2cDYT+C27Zokty3CMEhIdUo=";
+  vendorHash = "sha256-VpybX0AsVn2EMIvRjPaKIU+ZvmnhA9byav0o09YVlqc=";
   proxyVendor = true;
   nativeBuildInputs = [autoPatchelfHook];
   ldFlags = ["-X 'github.com/getAlby/hub/version.Tag=${version}'"];

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
     supportedSystems = ["x86_64-linux" "aarch64-linux"];
     pkgsBySystem = nixpkgs.lib.getAttrs supportedSystems nixpkgs.legacyPackages;
     forAllPkgs = fn: nixpkgs.lib.mapAttrs (system: pkgs: (fn pkgs)) pkgsBySystem;
-    version = "1.7.3";
+    version = "1.10.4";
   in {
     formatter = forAllPkgs (pkgs: pkgs.alejandra);
     packages = forAllPkgs (pkgs: {
@@ -16,7 +16,7 @@
         owner = "getAlby";
         repo = "hub";
         rev = "v${version}";
-        hash = "sha256-r0hIwtlsn1qd7c88DIMimuqOecLocF0Y19aK3My/DxQ=";
+        hash = "sha256-FIgWwQ6K7zJNUhVWW75oYZjvnOMOwgLCxhFYeJWHAM4=";
       };
       albyHubUI = pkgs.callPackage ./frontend.nix {
         inherit version;

--- a/frontend.nix
+++ b/frontend.nix
@@ -10,7 +10,7 @@
 }: let
   offlineCache = fetchYarnDeps {
     yarnLock = "${albyHubSrc}/frontend/yarn.lock";
-    hash = "sha256-Fvrg3CwouVJ4Dm/WAztptwXOY7fU+gYSAXdLT7srmyY=";
+    hash = "sha256-3hJyM6V6828RCUEqwUHeX3fy6LKgspyG4Q0fgxCF+V4=";
   };
 in
   stdenv.mkDerivation {

--- a/wails.nix
+++ b/wails.nix
@@ -22,7 +22,7 @@
 }: let
   offlineCache = fetchYarnDeps {
     yarnLock = "${albyHubSrc}/frontend/yarn.lock";
-    hash = "sha256-Fvrg3CwouVJ4Dm/WAztptwXOY7fU+gYSAXdLT7srmyY=";
+    hash = "sha256-3hJyM6V6828RCUEqwUHeX3fy6LKgspyG4Q0fgxCF+V4=";
   };
   deps = stdenv.mkDerivation {
     pname = "alby-hub-deps";
@@ -47,7 +47,7 @@
     '';
     outputHashMode = "recursive";
     outputHashAlgo = "sha256";
-    outputHash = "sha256-KgZOuNPKKI7d7pGBcWcuFg/UYaEh7EYfKqZC0ZFTJ8Q=";
+    outputHash = "sha256-9PdJArU8ovYPmFMpVU9MVdlD4o8kDwjWAw0rPcCMhkQ=";
     dontFixup = true;
   };
 in


### PR DESCRIPTION
just updates the version / hashes. Tested running http server and wails build locally on `x86_64-linux`.