### PR TITLE
Update to 1.12.0

### DIFF
--- a/alby-hub.nix
+++ b/alby-hub.nix
@@ -24,7 +24,7 @@ buildGoModule {
       # add frontend drv output to src
       cp -r ${albyHubUI}/dist $out/frontend/dist
     '';
-  vendorHash = "sha256-VpybX0AsVn2EMIvRjPaKIU+ZvmnhA9byav0o09YVlqc=";
+  vendorHash = "sha256-fHEDJ2M2uLMDrKisD/hhN5Bbfi+v7GBMMBJoXtybwIw=";
   proxyVendor = true;
   nativeBuildInputs = [autoPatchelfHook];
   ldFlags = ["-X 'github.com/getAlby/hub/version.Tag=${version}'"];

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1725826545,
-        "narHash": "sha256-L64N1rpLlXdc94H+F6scnrbuEu+utC03cDDVvvJGOME=",
+        "lastModified": 1734323986,
+        "narHash": "sha256-m/lh6hYMIWDYHCAsn81CDAiXoT3gmxXI9J987W5tZrE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f4c846aee8e1e29062aa8514d5e0ab270f4ec2f9",
+        "rev": "394571358ce82dff7411395829aa6a3aad45b907",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.05",
+        "ref": "nixos-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
   outputs = {
     self,
     nixpkgs,
@@ -8,7 +8,7 @@
     supportedSystems = ["x86_64-linux" "aarch64-linux"];
     pkgsBySystem = nixpkgs.lib.getAttrs supportedSystems nixpkgs.legacyPackages;
     forAllPkgs = fn: nixpkgs.lib.mapAttrs (system: pkgs: (fn pkgs)) pkgsBySystem;
-    version = "1.10.4";
+    version = "1.12.0";
   in {
     formatter = forAllPkgs (pkgs: pkgs.alejandra);
     packages = forAllPkgs (pkgs: {
@@ -16,7 +16,7 @@
         owner = "getAlby";
         repo = "hub";
         rev = "v${version}";
-        hash = "sha256-FIgWwQ6K7zJNUhVWW75oYZjvnOMOwgLCxhFYeJWHAM4=";
+        hash = "sha256-m3ImIz9qQVFZAjZPuVFkGANhWFIJp0uGDknfhouHHBo=";
       };
       albyHubUI = pkgs.callPackage ./frontend.nix {
         inherit version;

--- a/frontend.nix
+++ b/frontend.nix
@@ -10,7 +10,7 @@
 }: let
   offlineCache = fetchYarnDeps {
     yarnLock = "${albyHubSrc}/frontend/yarn.lock";
-    hash = "sha256-3hJyM6V6828RCUEqwUHeX3fy6LKgspyG4Q0fgxCF+V4=";
+    hash = "sha256-QFhIpJkd426c3GaDSpI36CxlNGVKQoSN8wDgAVh9Ee4=";
   };
 in
   stdenv.mkDerivation {

--- a/wails.nix
+++ b/wails.nix
@@ -16,13 +16,13 @@
   stdenv,
   version,
   wails,
-  webkitgtk,
+  webkitgtk_4_1,
   yarn,
   ...
 }: let
   offlineCache = fetchYarnDeps {
     yarnLock = "${albyHubSrc}/frontend/yarn.lock";
-    hash = "sha256-3hJyM6V6828RCUEqwUHeX3fy6LKgspyG4Q0fgxCF+V4=";
+    hash = "sha256-QFhIpJkd426c3GaDSpI36CxlNGVKQoSN8wDgAVh9Ee4=";
   };
   deps = stdenv.mkDerivation {
     pname = "alby-hub-deps";
@@ -47,7 +47,7 @@
     '';
     outputHashMode = "recursive";
     outputHashAlgo = "sha256";
-    outputHash = "sha256-9PdJArU8ovYPmFMpVU9MVdlD4o8kDwjWAw0rPcCMhkQ=";
+    outputHash = "sha256-/fOx3i+kb8reloVF3ZfHoKRiochKg4jIBbe7MYDOr00=";
     dontFixup = true;
   };
 in
@@ -75,7 +75,7 @@ in
       stdenv.cc
       stdenv.cc.cc.lib
       gtk3
-      webkitgtk
+      webkitgtk_4_1
     ];
     buildPhase = ''
       export HOME=$(mktemp -d)


### PR DESCRIPTION
This required updating the base nixpkgs to 24.11, since it requires a newer go version. 24.05 is depreciated anyways.