### PR TITLE
Update 1.16.0

### DIFF
--- a/alby-hub.nix
+++ b/alby-hub.nix
@@ -1,5 +1,6 @@
 {
   albyHubSrc,
+  albyHubUI,
   autoPatchelfHook,
   buildGoModule,
   callPackage,
@@ -14,17 +15,14 @@
 buildGoModule {
   pname = "alby-hub";
   inherit version;
-  src = let
-    albyHubUI = callPackage ./frontend.nix {inherit albyHubSrc version;};
-  in
-    runCommand "albyHubBackendSrc" {} ''
-      mkdir $out
-      cp -rT ${albyHubSrc} $out
-      chmod -R +rw $out
-      # add frontend drv output to src
-      cp -r ${albyHubUI}/dist $out/frontend/dist
-    '';
-  vendorHash = "sha256-fHEDJ2M2uLMDrKisD/hhN5Bbfi+v7GBMMBJoXtybwIw=";
+  src = runCommand "albyHubBackendSrc" {} ''
+    mkdir $out
+    cp -rT ${albyHubSrc} $out
+    chmod -R +rw $out
+    # add frontend drv output to src
+    cp -r ${albyHubUI}/dist $out/frontend/dist
+  '';
+  vendorHash = "sha256-rfZ6CV16T2qfwCJOi9OLh5el0o9IKVtuer8sj++XFqI=";
   proxyVendor = true;
   nativeBuildInputs = [autoPatchelfHook];
   ldFlags = ["-X 'github.com/getAlby/hub/version.Tag=${version}'"];
@@ -46,4 +44,5 @@ buildGoModule {
     mv $out/bin/http $out/bin/alby-hub
     patchelf --shrink-rpath --allowed-rpath-prefixes /nix/store $out/bin/alby-hub
   '';
+  meta.mainProgram = "alby-hub";
 }

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1734323986,
-        "narHash": "sha256-m/lh6hYMIWDYHCAsn81CDAiXoT3gmxXI9J987W5tZrE=",
+        "lastModified": 1736200483,
+        "narHash": "sha256-JO+lFN2HsCwSLMUWXHeOad6QUxOuwe9UOAF/iSl1J4I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "394571358ce82dff7411395829aa6a3aad45b907",
+        "rev": "3f0a8ac25fb674611b98089ca3a5dd6480175751",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
     supportedSystems = ["x86_64-linux" "aarch64-linux"];
     pkgsBySystem = nixpkgs.lib.getAttrs supportedSystems nixpkgs.legacyPackages;
     forAllPkgs = fn: nixpkgs.lib.mapAttrs (system: pkgs: (fn pkgs)) pkgsBySystem;
-    version = "1.12.0";
+    version = "1.13.0";
   in {
     formatter = forAllPkgs (pkgs: pkgs.alejandra);
     packages = forAllPkgs (pkgs: {
@@ -16,7 +16,7 @@
         owner = "getAlby";
         repo = "hub";
         rev = "v${version}";
-        hash = "sha256-m3ImIz9qQVFZAjZPuVFkGANhWFIJp0uGDknfhouHHBo=";
+        hash = "sha256-9ii11DHjcJtKfpYLeBn+ZjsChKq0ogRrxwCBeABQvBI=";
       };
       albyHubUI = pkgs.callPackage ./frontend.nix {
         inherit version;
@@ -25,10 +25,12 @@
       albyHub = pkgs.callPackage ./alby-hub.nix {
         inherit version;
         inherit (self.packages.${pkgs.system}) albyHubSrc;
+        inherit (self.packages.${pkgs.system}) albyHubUI;
       };
       wails = pkgs.callPackage ./wails.nix {
         inherit version;
         inherit (self.packages.${pkgs.system}) albyHubSrc;
+        inherit (self.packages.${pkgs.system}) albyHubUI;
       };
       default = self.packages.${pkgs.system}.albyHub;
     });

--- a/frontend.nix
+++ b/frontend.nix
@@ -35,4 +35,7 @@ in
       mkdir -p $out
       mv dist $out
     '';
+    passthru = {
+      inherit offlineCache;
+    };
   }


### PR DESCRIPTION
Once again wails build is broken

There is another problem and that is that the build seems to fail intermittently. This is the case pre-update though, and I genuinely cannot figure out why that is happening.

I recommend you squash the commits here, since it includes my previous commit to update to 1.13.0